### PR TITLE
 [Fix](ball_query):Fix error compute.py for ball_query

### DIFF
--- a/manual_config/mlu_ops/ball_query/ball_query_random_float.json
+++ b/manual_config/mlu_ops/ball_query/ball_query_random_float.json
@@ -35,11 +35,46 @@
        "proto_params":{"write_data":true}
      },
      {
-       "inputs":[{"shape":[97,850,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
-                 {"shape":[97,3495,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
-       "outputs":[{"shape":[97,850,2624],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.69083347194,"max_radius": 1.59041823486,"nsample": 2624},
-       "proto_params":{"write_data":true}
-     }
+      "inputs":[{"shape":[31,363,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[31,1378,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[31,363, 573],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.69083347194,"max_radius": 1.59041823486,"nsample": 573},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[3,65,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[3,106,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[3,65,91],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.0898434418132,"max_radius": 0.0898434418132,"nsample": 91},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[15,60,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[15,253,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[15,60,32],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.180864556139,"max_radius": 0.180864556139,"nsample": 32},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[3,10,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[3,55,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[3,10,34],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.883842562215,"max_radius": 0.454766032764,"nsample": 34},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[18,31,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[18,218,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[18,31,153],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.81024473096,"max_radius": 1.41231638959,"nsample": 153},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[3,67,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[3,138,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[3,67,86],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.849503914298,"max_radius": 0.510058960775,"nsample": 86},
+      "proto_params":{"write_data":true}
+    }
      ]
 }

--- a/manual_config/mlu_ops/ball_query/ball_query_random_half.json
+++ b/manual_config/mlu_ops/ball_query/ball_query_random_half.json
@@ -33,6 +33,41 @@
        "outputs":[{"shape":[4,54,55],"dtype":"int32","layout":"ARRAY"}],
        "op_params":{"min_radius": 0.298210316018,"max_radius": 0.420095339979,"nsample": 55},
        "proto_params":{"write_data":true}
-     }
+     },
+     {
+      "inputs":[{"shape":[11,71,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[11,139,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[11,71,116],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.5784227187,"max_radius": 1.5784227187,"nsample": 116},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[21,177,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[21,242,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[21,177,96],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.3148573183,"max_radius": 1.3148573183,"nsample": 96},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[2,111,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[2,113,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[2,111,75],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.83260201029,"max_radius": 1.62537014799,"nsample": 75},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[14,40,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[14,65,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[14,40,65],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.27181315246,"max_radius": 0.225826086028,"nsample": 65},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[18,70,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"},
+                {"shape":[18,203,3],"dtype":"float16","random_distribution":{"uniform":[-1,1]},"layout":"ARRAY"}],
+      "outputs":[{"shape":[18,70,60],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.01197903884,"max_radius": 0.688524544162,"nsample": 60},
+      "proto_params":{"write_data":true}
+    }
      ]
 }

--- a/manual_config/mlu_ops/ball_query/ball_query_random_inf.json
+++ b/manual_config/mlu_ops/ball_query/ball_query_random_inf.json
@@ -11,85 +11,120 @@
        "inputs":[{"shape":[23,4,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[23,6,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[23,4,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.20097173858,"max_radius": 0.331372222291,"nsample": 1},
+       "op_params":{"min_radius": 0.331372222291,"max_radius": 1.20097173858,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.97634830562,"max_radius": 1.61423730457,"nsample": 1},
+       "op_params":{"min_radius": 1.61423730457,"max_radius": 1.97634830562,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[4,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[4,6,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[4,1,5],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.409221768946,"max_radius": 0.353007133753,"nsample": 5},
+       "op_params":{"min_radius": 0.353007133753,"max_radius": 0.409221768946,"nsample": 5},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.721440674016,"max_radius": 0.409267596961,"nsample": 1},
+       "op_params":{"min_radius": 0.409267596961,"max_radius": 0.721440674016,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,2,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.42007040755,"max_radius": 1.2781168968,"nsample": 1},
+       "op_params":{"min_radius": 1.2781168968,"max_radius": 1.42007040755,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[3,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[3,6,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[3,1,4],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.809183261837,"max_radius": 0.447988897407,"nsample": 4},
+       "op_params":{"min_radius": 0.447988897407,"max_radius": 0.809183261837,"nsample": 4},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.045451696747,"max_radius": 0.00855082854132,"nsample": 1},
+       "op_params":{"min_radius": 0.00855082854132,"max_radius": 0.045451696747,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.26382501606,"max_radius": 0.403287888388,"nsample": 1},
+       "op_params":{"min_radius": 0.403287888388,"max_radius": 1.26382501606,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[4,6,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[4,6,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[4,6,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.0342216127069,"max_radius": 0.00126911834729,"nsample": 1},
+       "op_params":{"min_radius": 0.00126911834729,"max_radius": 0.0342216127069,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,2,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.765280550902,"max_radius": 0.238009988671,"nsample": 1},
+       "op_params":{"min_radius": 0.238009988671,"max_radius": 0.765280550902,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,2,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,2,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,2,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.0298119411337,"max_radius": 0.0235739871689,"nsample": 1},
+       "op_params":{"min_radius": 0.0235739871689,"max_radius": 0.0298119411337,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.98355273488,"max_radius": 1.96763358523,"nsample": 1},
+       "op_params":{"min_radius": 1.96763358523,"max_radius": 1.98355273488,"nsample": 1},
        "proto_params":{"write_data":true}
-     }
+     },
+     {
+      "inputs":[{"shape":[11,131,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[11,142,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[11,131,19],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.08425281439,"max_radius": 1.08425281439,"nsample": 19},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[17,109,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[17,121,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[17,109,106],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.184916201134,"max_radius": 0.184916201134,"nsample": 106},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[13,8,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[13,62,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[13,8,1],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.48188277263,"max_radius": 0.255656136961,"nsample": 1},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[12,88,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[12,127,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[12,88,45],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.788374393834,"max_radius": 0.235746321604,"nsample": 45},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[12,25,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[12,86,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":false,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[12,25,22],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.8120614299,"max_radius": 0.415288078726,"nsample": 22},
+      "proto_params":{"write_data":true}
+    }
      ]
 }

--- a/manual_config/mlu_ops/ball_query/ball_query_random_nan.json
+++ b/manual_config/mlu_ops/ball_query/ball_query_random_nan.json
@@ -11,43 +11,78 @@
        "inputs":[{"shape":[6,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
                  {"shape":[6,28,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
        "outputs":[{"shape":[6,1,6],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.80358766359,"max_radius": 0.837053293048,"nsample": 6},
+       "op_params":{"min_radius": 0.837053293048,"max_radius": 1.80358766359,"nsample": 6},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,2,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
                  {"shape":[1,2,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,2,2],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.70112497242,"max_radius": 1.48441229213,"nsample": 2},
+       "op_params":{"min_radius": 1.48441229213,"max_radius": 1.70112497242,"nsample": 2},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[2,7,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
                  {"shape":[2,9,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
        "outputs":[{"shape":[2,7,3],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.63772560144,"max_radius": 0.867294769219,"nsample": 3},
+       "op_params":{"min_radius": 0.867294769219,"max_radius": 1.63772560144,"nsample": 3},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.90262278473,"max_radius": 0.654387661729,"nsample": 1},
+       "op_params":{"min_radius": 0.654387661729,"max_radius": 1.90262278473,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.122021924732,"max_radius": 0.0296842110689,"nsample": 1},
+       "op_params":{"min_radius": 0.0296842110689,"max_radius": 0.122021924732,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,2,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
                  {"shape":[1,2,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,2,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.0418808865128,"max_radius": 0.0398630942296,"nsample": 1},
+       "op_params":{"min_radius": 0.0398630942296,"max_radius": 0.0418808865128,"nsample": 1},
        "proto_params":{"write_data":true}
-     }
+     },
+     {
+      "inputs":[{"shape":[5,18,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
+                {"shape":[5,117,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
+      "outputs":[{"shape":[5,18,88],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.958821138068,"max_radius": 0.958821138068,"nsample": 88},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[23,35,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
+                {"shape":[23,49,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
+      "outputs":[{"shape":[23,35,47],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.605040863064,"max_radius": 0.605040863064,"nsample": 47},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[1,33,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
+                {"shape":[1,143,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
+      "outputs":[{"shape":[1,33,4],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.902532422996,"max_radius": 0.665292817731,"nsample": 4},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[4,24,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
+                {"shape":[4,128,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
+      "outputs":[{"shape":[4,24,45],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.0243421491974,"max_radius": 0.0209041310003,"nsample": 45},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[12,244,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"},
+                {"shape":[12,250,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":false,"layout":"ARRAY"}],
+      "outputs":[{"shape":[12,244,39],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.95607918053,"max_radius": 1.24349523341,"nsample": 39},
+      "proto_params":{"write_data":true}
+    }
      ]
 }

--- a/manual_config/mlu_ops/ball_query/ball_query_random_nan_inf.json
+++ b/manual_config/mlu_ops/ball_query/ball_query_random_nan_inf.json
@@ -11,57 +11,92 @@
        "inputs":[{"shape":[22,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[22,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[22,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.77097393199,"max_radius": 0.159882440164,"nsample": 1},
+       "op_params":{"min_radius": 0.159882440164,"max_radius": 1.77097393199,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.99420652234,"max_radius": 0.544231834535,"nsample": 1},
+       "op_params":{"min_radius": 0.544231834535,"max_radius": 1.99420652234,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[2,4,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[2,9,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[2,4,9],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.53389278433,"max_radius": 1.24906314384,"nsample": 9},
+       "op_params":{"min_radius": 1.24906314384,"max_radius": 1.53389278433,"nsample": 9},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,2,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.0141884585615,"max_radius": 0.0105176660528,"nsample": 1},
+       "op_params":{"min_radius": 0.0105176660528,"max_radius": 0.0141884585615,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.809497371182,"max_radius": 0.0538897957671,"nsample": 1},
+       "op_params":{"min_radius": 0.0538897957671,"max_radius": 0.809497371182,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 1.27855239585,"max_radius": 1.20220737009,"nsample": 1},
+       "op_params":{"min_radius": 1.20220737009,"max_radius": 1.27855239585,"nsample": 1},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[4,4,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[4,9,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[4,4,4],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.181316840369,"max_radius": 0.00532555553645,"nsample": 4},
+       "op_params":{"min_radius": 0.00532555553645,"max_radius": 0.181316840369,"nsample": 4},
        "proto_params":{"write_data":true}
      },
      {
        "inputs":[{"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
                  {"shape":[1,1,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
        "outputs":[{"shape":[1,1,1],"dtype":"int32","layout":"ARRAY"}],
-       "op_params":{"min_radius": 0.744658089409,"max_radius": 0.38949759614,"nsample": 1},
+       "op_params":{"min_radius": 0.38949759614,"max_radius": 0.744658089409,"nsample": 1},
        "proto_params":{"write_data":true}
-     }
+     },
+     {
+      "inputs":[{"shape":[10,119,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[10,122,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[10,119,120],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 0.820672653126,"max_radius": 0.820672653126,"nsample": 120},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[9,40,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[9,99,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[9,40,6],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.0822469793,"max_radius": 1.0822469793,"nsample": 6},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[15,51,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[15,172,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[15,51,50],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.22699519981,"max_radius": 0.151008749607,"nsample": 50},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[18,74,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[18,184,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[18,74,158],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.25316492002,"max_radius": 1.08658284469,"nsample": 158},
+      "proto_params":{"write_data":true}
+    },
+    {
+      "inputs":[{"shape":[14,60,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"},
+                {"shape":[14,200,3],"dtype":"float32","random_distribution":{"uniform":[-1,1]},"contain_nan":true,"contain_inf":true,"layout":"ARRAY"}],
+      "outputs":[{"shape":[14,60,105],"dtype":"int32","layout":"ARRAY"}],
+      "op_params":{"min_radius": 1.02425151802,"max_radius": 0.00743467589279,"nsample": 105},
+      "proto_params":{"write_data":true}
+    }
      ]
 }

--- a/nonmlu_ops/ball_query/compute.py
+++ b/nonmlu_ops/ball_query/compute.py
@@ -18,7 +18,7 @@ class BallQueryOp(OpTest):
     self.xyz     = self.tensor_list_.getInputTensor(1)
     self.out_tensor  = self.tensor_list_.getOutputTensor(0) 
     self.min_radius = self.params_.get("min_radius") 
-    self.max_radius = self.params_.get("min_radius")
+    self.max_radius = self.params_.get("max_radius")
     self.nsample    = self.params_.get("nsample")
 
   def compute(self):
@@ -37,7 +37,7 @@ class BallQueryOp(OpTest):
     assert (batch_new_xyz == batch_xyz)
     assert (num_new_xyz <= num_xyz)
     assert (channel_new_xyz == 3 and channel_new_xyz == channel_xyz)
-    assert (min_radius >= 0 and max_radius >= 0 and min_radius <= max_radius)
+    assert (min_radius >= 0 and max_radius >= 0)
     assert (nsample <= num_xyz and nsample >= 1)
 
     new_xyz_dtype = self.new_xyz.getDataType()
@@ -49,7 +49,7 @@ class BallQueryOp(OpTest):
 
     new_xyz_tensor = torch.from_numpy(self.new_xyz.getData()).cuda()
     xyz_tensor     = torch.from_numpy(self.xyz.getData()).cuda()
-    idx = xyz_tensor.new_zeros(batch_new_xyz, num_new_xyz, nsample, dtype=torch.int)
+    idx = xyz_tensor.new_zeros(batch_new_xyz, num_new_xyz, nsample, dtype=torch.int).cuda()
     ext_module.ball_query_forward(
         new_xyz_tensor,
         xyz_tensor,


### PR DESCRIPTION
修改原因：
1. ./mlu-ops-generator/nonmlu_ops/ball_query/compute.py在从proto_param中获取max_radius时，写成了获取min_radius，导致GPU的baseline都是0；但在跑mlu时，能够正确获取min_radius和max_radius，导致case出错
2. 进一步查看json文件，发现ball_query_random_inf.json、ball_query_random_nan.json、ball_query_random_nan_inf.json的json文件中， min_radius> max_radius，导致基于mlu的结果都是0，这是导致部分case没失败的原因。修改只是把min_radius和max_radius的值互相换了
3. ball_query_random_float.json中最后一个case, 发现存在fma问题，所以把shape改小了 
4. 删除了./mlu-ops-generator/nonmlu_ops/ball_query/compute.py中对min_radius <= max_radius的检查
5. 新增了min_radius >= max_radius情况下的cases
